### PR TITLE
Fix recursion errors in Ascleandict and validate dataclass exports

### DIFF
--- a/src/lob_hlpr/hlpr.py
+++ b/src/lob_hlpr/hlpr.py
@@ -213,36 +213,54 @@ class LobHlpr:
                 return False
             return True
 
-        def _convert(obj: object) -> Any:
-            if is_dataclass(obj) and not isinstance(obj, type):
-                result = {}
-                for f in fields(obj):
-                    converted = _convert(getattr(obj, f.name))
-                    if _keep(converted):
-                        result[f.name] = converted
-                return result
-            if isinstance(obj, dict):
-                result = {}
-                for k, v in obj.items():
-                    converted = _convert(v)
-                    if _keep(converted):
-                        key = (
-                            str(k)
-                            if json_serializable and not isinstance(k, str)
-                            else k
-                        )
-                        result[key] = converted
-                return result
-            if isinstance(obj, (list, tuple)):
-                items = [_convert(item) for item in obj]
-                items = [item for item in items if _keep(item)]
-                return tuple(items) if isinstance(obj, tuple) else items
-            if json_serializable:
-                try:
-                    json.dumps(obj)
-                except (TypeError, OverflowError):
-                    return str(obj)
-            return obj
+        def _convert(obj: object, _seen: set | None = None) -> Any:
+            is_container = isinstance(obj, (dict, list)) or (
+                is_dataclass(obj) and not isinstance(obj, type)
+            )
+            if is_container:
+                if _seen is None:
+                    _seen = set()
+                obj_id = id(obj)
+                if obj_id in _seen:
+                    logging.getLogger(__name__).warning(
+                        "ascleandict: circular reference detected in %s, skipping",
+                        type(obj).__name__,
+                    )
+                    return f"<circular ref: {type(obj).__name__}>"
+                _seen.add(obj_id)
+            try:
+                if is_dataclass(obj) and not isinstance(obj, type):
+                    result = {}
+                    for f in fields(obj):
+                        converted = _convert(getattr(obj, f.name), _seen)
+                        if _keep(converted):
+                            result[f.name] = converted
+                    return result
+                if isinstance(obj, dict):
+                    result = {}
+                    for k, v in obj.items():
+                        converted = _convert(v, _seen)
+                        if _keep(converted):
+                            key = (
+                                str(k)
+                                if json_serializable and not isinstance(k, str)
+                                else k
+                            )
+                            result[key] = converted
+                    return result
+                if isinstance(obj, (list, tuple)):
+                    items = [_convert(item, _seen) for item in obj]
+                    items = [item for item in items if _keep(item)]
+                    return tuple(items) if isinstance(obj, tuple) else items
+                if json_serializable:
+                    try:
+                        json.dumps(obj)
+                    except (TypeError, OverflowError):
+                        return str(obj)
+                return obj
+            finally:
+                if is_container:
+                    _seen.discard(obj_id)
 
         return _convert(dclass)
 

--- a/tests/test_lob_hlpr.py
+++ b/tests/test_lob_hlpr.py
@@ -415,6 +415,37 @@ def test_ascleandict_nested_cleanup_multiple_passes():
     assert result == {"name": "test"}
 
 
+def test_ascleandict_circular_reference_in_list():
+    """Test that ascleandict handles a circular list reference without crashing."""
+
+    @dataclass
+    class Node:
+        items: list
+
+    circular_list: list = []
+    circular_list.append(circular_list)  # List references itself
+    node = Node(items=circular_list)
+
+    result = hlp.ascleandict(node)
+    # The circular entry is replaced with a sentinel string, not empty, so kept
+    assert result["items"] == ["<circular ref: list>"]
+
+
+def test_ascleandict_circular_reference_in_dict():
+    """Test that ascleandict handles a circular dict reference without crashing."""
+
+    @dataclass
+    class Container:
+        data: dict
+
+    circular_dict: dict = {}
+    circular_dict["self"] = circular_dict  # Dict references itself
+    container = Container(data=circular_dict)
+
+    result = hlp.ascleandict(container)
+    assert result["data"]["self"] == "<circular ref: dict>"
+
+
 def test_unix_timestamp():
     """Test unix_timestamp function."""
     timestamp = hlp.unix_timestamp()


### PR DESCRIPTION
This pull request improves the robustness of the `ascleandict` utility in `src/lob_hlpr/hlpr.py` by adding detection and handling of circular references in dataclasses, lists, and dictionaries. It also adds new tests to ensure that these cases are handled gracefully without causing crashes or infinite recursion.

Handling of circular references:

* Updated the internal `_convert` function to track seen objects using their IDs, detect circular references in containers (dataclasses, lists, dicts), and replace them with a sentinel string (e.g., `"<circular ref: list>"`). This prevents infinite recursion and logs a warning when a circular reference is detected. [[1]](diffhunk://#diff-11e406701640f24a0c3b68b95403f39b2ec5d75642faea2058e86f45c5bb68caL216-R242) [[2]](diffhunk://#diff-11e406701640f24a0c3b68b95403f39b2ec5d75642faea2058e86f45c5bb68caL237-R252) [[3]](diffhunk://#diff-11e406701640f24a0c3b68b95403f39b2ec5d75642faea2058e86f45c5bb68caR261-R263)

Testing:

* Added `test_ascleandict_circular_reference_in_list` and `test_ascleandict_circular_reference_in_dict` to verify that circular references in lists and dicts are handled as expected and do not cause crashes.